### PR TITLE
Refactoring to reduce conditional statements and enhance extensibility of tests

### DIFF
--- a/network/benchmarks/netperf/Makefile
+++ b/network/benchmarks/netperf/Makefile
@@ -18,9 +18,7 @@ DOCKERREPO := $(or $(DOCKERREPO), girishkalele/netperf-latest)
 
 docker: launch
 	mkdir -p Dockerbuild && \
-	cp -f Dockerfile Dockerbuild/ && \
-    cp -f nptest/nptest.go Dockerbuild/ && \
-    cp -f nptest/go.mod Dockerbuild/ && \
+	cp -rf nptest/* Dockerbuild/ && \
 	docker build -t $(DOCKERREPO) Dockerbuild/
 
 push: docker

--- a/network/benchmarks/netperf/nptest/Dockerfile
+++ b/network/benchmarks/netperf/nptest/Dockerfile
@@ -24,8 +24,7 @@
 FROM golang:bullseye AS builder
 WORKDIR /workspace
 
-COPY nptest.go nptest.go
-COPY go.mod go.mod
+COPY . .
 
 RUN go build -o nptests
 

--- a/network/benchmarks/netperf/nptest/parsers/bandwidth_parsers.go
+++ b/network/benchmarks/netperf/nptest/parsers/bandwidth_parsers.go
@@ -1,0 +1,45 @@
+package parsers
+
+import (
+	"regexp"
+)
+
+func ParseIperfTCPBandwidth(output string) string {
+	// Parses the output of iperf3 and grabs the group Mbits/sec from the output
+	iperfTCPOutputRegexp := regexp.MustCompile("SUM.*\\s+(\\d+)\\sMbits/sec\\s+receiver")
+	match := iperfTCPOutputRegexp.FindStringSubmatch(output)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return "0"
+}
+
+func ParseIperfSctpBandwidth(output string) string {
+	// Parses the output of iperf3 and grabs the group Mbits/sec from the output
+	iperfSCTPOutputRegexp := regexp.MustCompile("SUM.*\\s+(\\d+)\\sMbits/sec\\s+receiver")
+	match := iperfSCTPOutputRegexp.FindStringSubmatch(output)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return "0"
+}
+
+func ParseIperfUDPBandwidth(output string) string {
+	// Parses the output of iperf3 (UDP mode) and grabs the Mbits/sec from the output
+	iperfUDPOutputRegexp := regexp.MustCompile("\\s+(\\S+)\\sMbits/sec\\s+\\S+\\s+ms\\s+")
+	match := iperfUDPOutputRegexp.FindStringSubmatch(output)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return "0"
+}
+
+func ParseNetperfBandwidth(output string) string {
+	// Parses the output of netperf and grabs the Bbits/sec from the output
+	netperfOutputRegexp := regexp.MustCompile("\\s+\\d+\\s+\\d+\\s+\\d+\\s+\\S+\\s+(\\S+)\\s+")
+	match := netperfOutputRegexp.FindStringSubmatch(output)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return "0"
+}

--- a/network/benchmarks/netperf/nptest/parsers/json_parsers.go
+++ b/network/benchmarks/netperf/nptest/parsers/json_parsers.go
@@ -1,0 +1,116 @@
+package parsers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+func ParseIperfThrouputTCPTest(output string) string {
+	var iperfThroughput struct {
+		End struct {
+			Streams []struct {
+				Sender struct {
+					BitsPerSecond     float64 `json:"bits_per_second"`
+					MeanRoundTripTime int     `json:"mean_rtt"`
+					MinRoundTripTime  int     `json:"min_rtt"`
+					MaxRoundTripTime  int     `json:"max_rtt"`
+					Retransmits       int     `json:"retransmits"`
+				} `json:"sender"`
+			} `json:"streams"`
+			CPUUtilizationPercent struct {
+				HostTotal   float64 `json:"host_total"`
+				RemoteTotal float64 `json:"remote_total"`
+			} `json:"cpu_utilization_percent"`
+		} `json:"end"`
+	}
+
+	fmt.Println("Parsing iperf output\n", output)
+	fmt.Println("End of iperf output")
+
+	err := json.Unmarshal([]byte(output), &iperfThroughput)
+	if err != nil {
+		return "{\"error\": \"Failed to parse JSON output\", \"message\": \"" + err.Error() + "\"}"
+	}
+
+	if len(iperfThroughput.End.Streams) != 1 {
+		return "{\"error\": \"Failed to parse JSON output\", \"message\": \"Expected 1 stream, got " + strconv.Itoa(len(iperfThroughput.End.Streams)) + "\"}"
+	}
+
+	var outputResult struct {
+		TotalThroughput   float64 `json:"total_throughput"`
+		MeanRoundTripTime int     `json:"mean_rtt"`
+		MinRoundTripTime  int     `json:"min_rtt"`
+		MaxRoundTripTime  int     `json:"max_rtt"`
+		Retransmits       int     `json:"retransmits"`
+		CPUUtilization    struct {
+			Host   float64 `json:"host"`
+			Remote float64 `json:"remote"`
+		} `json:"cpu_utilization"`
+	}
+
+	outputResult.TotalThroughput = iperfThroughput.End.Streams[0].Sender.BitsPerSecond / 1e6
+	outputResult.MeanRoundTripTime = iperfThroughput.End.Streams[0].Sender.MeanRoundTripTime
+	outputResult.MinRoundTripTime = iperfThroughput.End.Streams[0].Sender.MinRoundTripTime
+	outputResult.MaxRoundTripTime = iperfThroughput.End.Streams[0].Sender.MaxRoundTripTime
+	outputResult.CPUUtilization.Host = iperfThroughput.End.CPUUtilizationPercent.HostTotal
+	outputResult.CPUUtilization.Remote = iperfThroughput.End.CPUUtilizationPercent.RemoteTotal
+
+	parsedJson, err := json.Marshal(outputResult)
+	if err != nil {
+		return "{\"error\": \"Failed to marshal JSON output\", \"message\": \"" + err.Error() + "\"}"
+	}
+
+	return string(parsedJson)
+}
+
+func ParseIperfThrouputUDPTest(output string) string {
+	fmt.Println("Parsing iperf output\n", output)
+	var iperfThroughput struct {
+		End struct {
+			Sum struct {
+				BitsPerSecond float64 `json:"bits_per_second"`
+				Jitter        float64 `json:"jitter_ms"`
+				LostPackets   int     `json:"lost_packets"`
+				TotalPackets  int     `json:"packets"`
+				LostPercent   float64 `json:"lost_percent"`
+			} `json:"sum"`
+			CPUUtilizationPercent struct {
+				HostTotal   float64 `json:"host_total"`
+				RemoteTotal float64 `json:"remote_total"`
+			} `json:"cpu_utilization_percent"`
+		} `json:"end"`
+	}
+
+	err := json.Unmarshal([]byte(output), &iperfThroughput)
+	if err != nil {
+		return "{\"error\": \"Failed to parse JSON output\", \"message\": \"" + err.Error() + "\"}"
+	}
+
+	var outputResult struct {
+		TotalThroughput float64 `json:"total_throughput"`
+		Jitter          float64 `json:"jitter_ms"`
+		LostPackets     int     `json:"lost_packets"`
+		TotalPackets    int     `json:"total_packets"`
+		LostPercent     float64 `json:"lost_percent"`
+		CPUUtilization  struct {
+			Host   float64 `json:"host"`
+			Remote float64 `json:"remote"`
+		} `json:"cpu_utilization"`
+	}
+
+	outputResult.TotalThroughput = iperfThroughput.End.Sum.BitsPerSecond / 1e6
+	outputResult.Jitter = iperfThroughput.End.Sum.Jitter
+	outputResult.LostPackets = iperfThroughput.End.Sum.LostPackets
+	outputResult.TotalPackets = iperfThroughput.End.Sum.TotalPackets
+	outputResult.LostPercent = iperfThroughput.End.Sum.LostPercent
+	outputResult.CPUUtilization.Host = iperfThroughput.End.CPUUtilizationPercent.HostTotal
+	outputResult.CPUUtilization.Remote = iperfThroughput.End.CPUUtilizationPercent.RemoteTotal
+
+	parsedJson, err := json.Marshal(outputResult)
+	if err != nil {
+		return "{\"error\": \"Failed to marshal JSON output\", \"message\": \"" + err.Error() + "\"}"
+	}
+
+	return string(parsedJson)
+}

--- a/network/benchmarks/netperf/nptest/tests.go
+++ b/network/benchmarks/netperf/nptest/tests.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+	"k8s.io/perf-tests/network/nptest/parsers"
+)
+
 type TestType int
 
 const (
@@ -14,8 +18,10 @@ const (
 
 type testcase struct {
 	TestParams
-	Label    string
-	Finished bool
+	Label           string
+	Finished        bool
+	BandwidthParser func(string) string
+	JsonParser      func(string) string
 	// Deprecated: We will use declarative approach to define test cases
 	Type TestType
 }
@@ -31,212 +37,296 @@ type TestParams struct {
 var testcases = []*testcase{
 	// {
 	// 	Label: "1 qperf TCP. Same VM using Pod IP",
-	// 	SourceNode: "netperf-w1",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: qperfTCPTest,
-	// 	ClusterIP: false,
-	// 	MsgSize: msgSizeMin,
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w1",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       false,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            qperfTCPTest,
 	// },
 	// {
 	// 	Label: "2 qperf TCP. Same VM using Virtual IP",
-	// 	SourceNode: "netperf-w1",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: qperfTCPTest,
-	// 	ClusterIP: true,
-	// 	MsgSize: msgSizeMin,
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w1",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       true,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            qperfTCPTest,
 	// },
 	// {
 	// 	Label: "3 qperf TCP. Remote VM using Pod IP",
-	// 	SourceNode: "netperf-w1",
-	// 	DestinationNode: "netperf-w3",
-	// 	Type: qperfTCPTest,
-	// 	ClusterIP: false,
-	// 	MsgSize: msgSizeMin,
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w1",
+	// 		DestinationNode: "netperf-w3",
+	// 		ClusterIP:       false,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            qperfTCPTest,
 	// },
 	// {
 	// 	Label: "4 qperf TCP. Remote VM using Virtual IP",
-	// 	SourceNode: "netperf-w3",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: qperfTCPTest,
-	// 	ClusterIP: true,
-	// 	MsgSize: msgSizeMin,
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w3",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       true,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            qperfTCPTest,
 	// },
 	// {
 	// 	Label: "5 qperf TCP. Hairpin Pod to own Virtual IP",
-	// 	SourceNode: "netperf-w2",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: qperfTCPTest,
-	// 	ClusterIP: true,
-	// 	MsgSize: msgSizeMin,
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w2",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       true,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            qperfTCPTest,
 	// },
 
 	{
-		Label: "1 iperf TCP. Same VM using Pod IP",
+		Label: "6 iperf TCP. Same VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       false,
 			MSS:             mssMin,
 		},
-		Type: iperfTCPTest,
+		BandwidthParser: parsers.ParseIperfTCPBandwidth,
+		Type:            iperfTCPTest,
 	},
 	{
-		Label: "2 iperf TCP. Same VM using Virtual IP",
+		Label: "7 iperf TCP. Same VM using Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 			MSS:             mssMin,
 		},
-		Type: iperfTCPTest,
+		BandwidthParser: parsers.ParseIperfTCPBandwidth,
+		Type:            iperfTCPTest,
 	},
 	{
-		Label: "3 iperf TCP. Remote VM using Pod IP",
+		Label: "8 iperf TCP. Remote VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w3",
 			ClusterIP:       false,
 			MSS:             mssMin,
 		},
-		Type: iperfTCPTest,
+		BandwidthParser: parsers.ParseIperfTCPBandwidth,
+		Type:            iperfTCPTest,
 	},
 	{
-		Label: "4 iperf TCP. Remote VM using Virtual IP",
+		Label: "9 iperf TCP. Remote VM using Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w3",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 			MSS:             mssMin,
 		},
-		Type: iperfTCPTest,
+		BandwidthParser: parsers.ParseIperfTCPBandwidth,
+		Type:            iperfTCPTest,
 	},
 	{
-		Label: "5 iperf TCP. Hairpin Pod to own Virtual IP",
+		Label: "10 iperf TCP. Hairpin Pod to own Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w2",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 			MSS:             mssMin,
 		},
-		Type: iperfTCPTest,
+		BandwidthParser: parsers.ParseIperfTCPBandwidth,
+		Type:            iperfTCPTest,
 	},
 
 	// {
-	// 	Label: "6 iperf SCTP. Same VM using Pod IP",
-	// 	SourceNode: "netperf-w1",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: iperfSctpTest,
-	// 	ClusterIP: false,
-	// 	MSS: mssMin,
+	// 	Label: "11 iperf SCTP. Same VM using Pod IP",
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w1",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       false,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            iperfSctpTest,
 	// },
 	// {
-	// 	Label: "7 iperf SCTP. Same VM using Virtual IP",
-	// 	SourceNode: "netperf-w1",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: iperfSctpTest,
-	// 	ClusterIP: true,
-	// 	MSS: mssMin,
+	// 	Label: "12 iperf SCTP. Same VM using Virtual IP",
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w1",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       true,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            iperfSctpTest,
 	// },
 	// {
-	// 	Label: "8 iperf SCTP. Remote VM using Pod IP",
-	// 	SourceNode: "netperf-w1",
-	// 	DestinationNode: "netperf-w3",
-	// 	Type: iperfSctpTest,
-	// 	ClusterIP: false,
-	// 	MSS: mssMin,
+	// 	Label: "13 iperf SCTP. Remote VM using Pod IP",
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w1",
+	// 		DestinationNode: "netperf-w3",
+	// 		ClusterIP:       false,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            iperfSctpTest,
 	// },
 	// {
-	// 	Label: "9 iperf SCTP. Remote VM using Virtual IP",
-	// 	SourceNode: "netperf-w3",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: iperfSctpTest,
-	// 	ClusterIP: true,
-	// 	MSS: mssMin,
+	// 	Label: "14 iperf SCTP. Remote VM using Virtual IP",
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w3",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       true,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            iperfSctpTest,
 	// },
 	// {
-	// 	Label: "10 iperf SCTP. Hairpin Pod to own Virtual IP",
-	// 	SourceNode: "netperf-w2",
-	// 	DestinationNode: "netperf-w2",
-	// 	Type: iperfSctpTest,
-	// 	ClusterIP: true,
-	// 	MSS: mssMin,
+	// 	Label: "15 iperf SCTP. Hairpin Pod to own Virtual IP",
+	// 	TestParams: TestParams{
+	// 		SourceNode:      "netperf-w2",
+	// 		DestinationNode: "netperf-w2",
+	// 		ClusterIP:       true,
+	// 		MSS:             mssMin,
+	// 	},
+	// 	BandwidthParser: parsers.ParseIperfTCPBandwidth,
+	// 	Type:            iperfSctpTest,
 	// },
 
 	{
-		Label: "11 iperf UDP. Same VM using Virtual IP",
+		Label: "16 iperf UDP. Same VM using Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 			MSS:             mssMax,
 		},
-		Type: iperfUDPTest,
+		BandwidthParser: parsers.ParseIperfUDPBandwidth,
+		Type:            iperfUDPTest,
 	},
 	{
-		Label: "12 iperf UDP. Remote VM using Pod IP",
+		Label: "17 iperf UDP. Remote VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w3",
 			ClusterIP:       false,
 			MSS:             mssMax,
 		},
-		Type: iperfUDPTest,
+		BandwidthParser: parsers.ParseIperfUDPBandwidth,
+		Type:            iperfUDPTest,
 	},
 	{
-		Label: "13 iperf UDP. Remote VM using Virtual IP",
+		Label: "18 iperf UDP. Remote VM using Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w3",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 			MSS:             mssMax,
 		},
-		Type: iperfUDPTest,
+		BandwidthParser: parsers.ParseIperfUDPBandwidth,
+		Type:            iperfUDPTest,
 	},
 	{
-		Label: "14 netperf. Same VM using Pod IP",
+		Label: "19 netperf. Same VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       false,
 			MSS:             mssMax,
 		},
-		Type: iperfUDPTest,
+		BandwidthParser: parsers.ParseNetperfBandwidth,
+		Type:            netperfTest,
 	},
 
 	{
-		Label: "15 netperf. Same VM using Pod IP",
+		Label: "20 netperf. Same VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       false,
 		},
-		Type: netperfTest,
+		BandwidthParser: parsers.ParseNetperfBandwidth,
+		Type:            netperfTest,
 	},
 	{
-		Label: "16 netperf. Same VM using Virtual IP",
+		Label: "21 netperf. Same VM using Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 		},
-		Type: netperfTest,
+		BandwidthParser: parsers.ParseNetperfBandwidth,
+		Type:            netperfTest,
 	},
 	{
-		Label: "17 netperf. Remote VM using Pod IP",
+		Label: "22 netperf. Remote VM using Pod IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w1",
 			DestinationNode: "netperf-w3",
 			ClusterIP:       false,
 		},
-		Type: netperfTest,
+		BandwidthParser: parsers.ParseNetperfBandwidth,
+		Type:            netperfTest,
 	},
 	{
-		Label: "18 netperf. Remote VM using Virtual IP",
+		Label: "23 netperf. Remote VM using Virtual IP",
 		TestParams: TestParams{
 			SourceNode:      "netperf-w3",
 			DestinationNode: "netperf-w2",
 			ClusterIP:       true,
 		},
-		Type: netperfTest,
+		BandwidthParser: parsers.ParseNetperfBandwidth,
+		Type:            netperfTest,
+	},
+
+	{
+		Label: "24 iperf Throughput TCP. Same VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       false,
+		},
+		JsonParser: parsers.ParseIperfThrouputTCPTest,
+		Type:       iperfThroughputTest,
+	},
+	{
+		Label: "25 iperf Throughput TCP. Remote VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w3",
+			ClusterIP:       false,
+		},
+		JsonParser: parsers.ParseIperfThrouputTCPTest,
+		Type:       iperfThroughputTest,
+	},
+	{
+		Label: "26 iperf Throughput UDP. Remote VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w3",
+			ClusterIP:       false,
+		},
+		JsonParser: parsers.ParseIperfThrouputUDPTest,
+		Type:       iperfThroughputUDPTest,
+	},
+	{
+		Label: "27 iperf Throughput UDP. Same VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       false,
+		},
+		JsonParser: parsers.ParseIperfThrouputUDPTest,
+		Type:       iperfThroughputUDPTest,
 	},
 }

--- a/network/benchmarks/netperf/nptest/tests.go
+++ b/network/benchmarks/netperf/nptest/tests.go
@@ -1,0 +1,242 @@
+package main
+
+type TestType int
+
+const (
+	iperfTCPTest TestType = iota
+	qperfTCPTest
+	iperfUDPTest
+	iperfSctpTest
+	netperfTest
+	iperfThroughputTest
+	iperfThroughputUDPTest
+)
+
+type testcase struct {
+	TestParams
+	Label    string
+	Finished bool
+	// Deprecated: We will use declarative approach to define test cases
+	Type TestType
+}
+
+type TestParams struct {
+	SourceNode      string
+	DestinationNode string
+	ClusterIP       bool
+	MSS             int
+	MsgSize         int
+}
+
+var testcases = []*testcase{
+	// {
+	// 	Label: "1 qperf TCP. Same VM using Pod IP",
+	// 	SourceNode: "netperf-w1",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: qperfTCPTest,
+	// 	ClusterIP: false,
+	// 	MsgSize: msgSizeMin,
+	// },
+	// {
+	// 	Label: "2 qperf TCP. Same VM using Virtual IP",
+	// 	SourceNode: "netperf-w1",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: qperfTCPTest,
+	// 	ClusterIP: true,
+	// 	MsgSize: msgSizeMin,
+	// },
+	// {
+	// 	Label: "3 qperf TCP. Remote VM using Pod IP",
+	// 	SourceNode: "netperf-w1",
+	// 	DestinationNode: "netperf-w3",
+	// 	Type: qperfTCPTest,
+	// 	ClusterIP: false,
+	// 	MsgSize: msgSizeMin,
+	// },
+	// {
+	// 	Label: "4 qperf TCP. Remote VM using Virtual IP",
+	// 	SourceNode: "netperf-w3",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: qperfTCPTest,
+	// 	ClusterIP: true,
+	// 	MsgSize: msgSizeMin,
+	// },
+	// {
+	// 	Label: "5 qperf TCP. Hairpin Pod to own Virtual IP",
+	// 	SourceNode: "netperf-w2",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: qperfTCPTest,
+	// 	ClusterIP: true,
+	// 	MsgSize: msgSizeMin,
+	// },
+
+	{
+		Label: "1 iperf TCP. Same VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       false,
+			MSS:             mssMin,
+		},
+		Type: iperfTCPTest,
+	},
+	{
+		Label: "2 iperf TCP. Same VM using Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+			MSS:             mssMin,
+		},
+		Type: iperfTCPTest,
+	},
+	{
+		Label: "3 iperf TCP. Remote VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w3",
+			ClusterIP:       false,
+			MSS:             mssMin,
+		},
+		Type: iperfTCPTest,
+	},
+	{
+		Label: "4 iperf TCP. Remote VM using Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w3",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+			MSS:             mssMin,
+		},
+		Type: iperfTCPTest,
+	},
+	{
+		Label: "5 iperf TCP. Hairpin Pod to own Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w2",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+			MSS:             mssMin,
+		},
+		Type: iperfTCPTest,
+	},
+
+	// {
+	// 	Label: "6 iperf SCTP. Same VM using Pod IP",
+	// 	SourceNode: "netperf-w1",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: iperfSctpTest,
+	// 	ClusterIP: false,
+	// 	MSS: mssMin,
+	// },
+	// {
+	// 	Label: "7 iperf SCTP. Same VM using Virtual IP",
+	// 	SourceNode: "netperf-w1",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: iperfSctpTest,
+	// 	ClusterIP: true,
+	// 	MSS: mssMin,
+	// },
+	// {
+	// 	Label: "8 iperf SCTP. Remote VM using Pod IP",
+	// 	SourceNode: "netperf-w1",
+	// 	DestinationNode: "netperf-w3",
+	// 	Type: iperfSctpTest,
+	// 	ClusterIP: false,
+	// 	MSS: mssMin,
+	// },
+	// {
+	// 	Label: "9 iperf SCTP. Remote VM using Virtual IP",
+	// 	SourceNode: "netperf-w3",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: iperfSctpTest,
+	// 	ClusterIP: true,
+	// 	MSS: mssMin,
+	// },
+	// {
+	// 	Label: "10 iperf SCTP. Hairpin Pod to own Virtual IP",
+	// 	SourceNode: "netperf-w2",
+	// 	DestinationNode: "netperf-w2",
+	// 	Type: iperfSctpTest,
+	// 	ClusterIP: true,
+	// 	MSS: mssMin,
+	// },
+
+	{
+		Label: "11 iperf UDP. Same VM using Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+			MSS:             mssMax,
+		},
+		Type: iperfUDPTest,
+	},
+	{
+		Label: "12 iperf UDP. Remote VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w3",
+			ClusterIP:       false,
+			MSS:             mssMax,
+		},
+		Type: iperfUDPTest,
+	},
+	{
+		Label: "13 iperf UDP. Remote VM using Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w3",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+			MSS:             mssMax,
+		},
+		Type: iperfUDPTest,
+	},
+	{
+		Label: "14 netperf. Same VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       false,
+			MSS:             mssMax,
+		},
+		Type: iperfUDPTest,
+	},
+
+	{
+		Label: "15 netperf. Same VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       false,
+		},
+		Type: netperfTest,
+	},
+	{
+		Label: "16 netperf. Same VM using Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+		},
+		Type: netperfTest,
+	},
+	{
+		Label: "17 netperf. Remote VM using Pod IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w1",
+			DestinationNode: "netperf-w3",
+			ClusterIP:       false,
+		},
+		Type: netperfTest,
+	},
+	{
+		Label: "18 netperf. Remote VM using Virtual IP",
+		TestParams: TestParams{
+			SourceNode:      "netperf-w3",
+			DestinationNode: "netperf-w2",
+			ClusterIP:       true,
+		},
+		Type: netperfTest,
+	},
+}


### PR DESCRIPTION
This pull request includes a series of changes to improve the `netperf` benchmarking tool by refactoring code, removing unused components, and enhancing maintainability. The most important changes include refactoring the Docker build process, simplifying the `nptest.go` file, and moving parsing functions to a new dedicated file.

### Refactoring and Simplification:

* **Docker Build Process:**
  * Simplified the Docker build process by copying all files from `nptest` to `Dockerbuild` instead of specifying each file individually in the `Makefile`. (`network/benchmarks/netperf/Makefile`)
  * Renamed `Dockerfile` to `network/benchmarks/netperf/nptest/Dockerfile` and updated the `COPY` commands to copy all files at once. (`network/benchmarks/netperf/nptest/Dockerfile`)

* **Code Cleanup in `nptest.go`:**
  * Removed unused imports such as `encoding/json` and `regexp`. (`network/benchmarks/netperf/nptest/nptest.go`) [[1]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL29) [[2]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL38)
  * Deleted unused variables and constants related to test types and regex patterns. (`network/benchmarks/netperf/nptest/nptest.go`) [[1]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL61-L66) [[2]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL98-L107)
  * Removed the `testcase` struct and related initialization code, simplifying the setup process. (`network/benchmarks/netperf/nptest/nptest.go`) [[1]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL155-L169) [[2]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL180-L221)

* **Function Updates:**
  * Updated function signatures to use the new `TestType` enum instead of `int` for better type safety. (`network/benchmarks/netperf/nptest/nptest.go`) [[1]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL901-R615) [[2]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL918-R632)
  * Removed detailed parsing functions for `iperf` and `netperf` outputs, replacing them with a more streamlined approach. (`network/benchmarks/netperf/nptest/nptest.go`) [[1]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL477-L595) [[2]](diffhunk://#diff-3991faa915381fa4a66e7661142bce5df28168902234f0f1619e5ed4b0928b9cL616-R450)

### Code Organization:

* **New Parsing Functions File:**
  * Moved bandwidth parsing functions to a new file `bandwidth_parsers.go` under the `parsers` package for better code organization and separation of concerns. (`network/benchmarks/netperf/nptest/parsers/bandwidth_parsers.go`)